### PR TITLE
Refine dashboard with minimalist, app-consistent visual design

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -89,11 +89,11 @@ export default function DashboardPage() {
                     className="mb-6"
                 >
                     <div className="flex items-center gap-3 mb-1.5">
-                        <div className="p-2 rounded-lg bg-gradient-blue">
-                            <LayoutDashboard className="h-5 w-5 text-white" />
+                        <div className="flex h-9 w-9 items-center justify-center rounded-lg border bg-muted/40">
+                            <LayoutDashboard className="h-4 w-4 text-foreground" />
                         </div>
                         <div>
-                            <h1 className="text-2xl font-bold text-foreground leading-tight">
+                            <h1 className="text-2xl font-semibold text-foreground leading-tight">
                                 My Dashboard
                             </h1>
                             <p className="text-sm text-muted-foreground">

--- a/components/dashboard/dashboard-empty-state.tsx
+++ b/components/dashboard/dashboard-empty-state.tsx
@@ -10,47 +10,40 @@ interface DashboardEmptyStateProps {
     onClearFilters: () => void;
 }
 
-export function DashboardEmptyState({
-    hasFilters,
-    onClearFilters,
-}: DashboardEmptyStateProps) {
+export function DashboardEmptyState({ hasFilters, onClearFilters }: DashboardEmptyStateProps) {
     return (
         <motion.div
-            initial={{ opacity: 0, scale: 0.96 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{ duration: 0.35 }}
-            className="flex flex-col items-center justify-center py-16 px-6"
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.25 }}
+            className="flex flex-col items-center justify-center rounded-lg border bg-card px-6 py-14"
         >
-            <div className="w-16 h-16 rounded-2xl bg-muted flex items-center justify-center mb-5">
-                <ClipboardList className="h-8 w-8 text-muted-foreground" />
+            <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full border bg-muted/40">
+                <ClipboardList className="h-5 w-5 text-muted-foreground" />
             </div>
 
             {hasFilters ? (
                 <>
-                    <h3 className="text-lg font-semibold text-foreground mb-1.5">
-                        No tests match your filters
+                    <h3 className="mb-1 text-base font-semibold text-foreground">
+                        No matching tests found
                     </h3>
-                    <p className="text-sm text-muted-foreground text-center max-w-md mb-6">
-                        Try adjusting your search query or filter criteria to find the tests
-                        you&apos;re looking for.
+                    <p className="mb-5 max-w-md text-center text-sm text-muted-foreground">
+                        Adjust your filters or search terms to view more results.
                     </p>
                     <Button variant="outline" onClick={onClearFilters} size="sm">
-                        Clear Filters
+                        Clear filters
                     </Button>
                 </>
             ) : (
                 <>
-                    <h3 className="text-lg font-semibold text-foreground mb-1.5">
-                        No tests attempted yet
-                    </h3>
-                    <p className="text-sm text-muted-foreground text-center max-w-md mb-6">
-                        Start your exam preparation journey by taking your first mock test.
-                        Your performance history will appear here.
+                    <h3 className="mb-1 text-base font-semibold text-foreground">No tests yet</h3>
+                    <p className="mb-5 max-w-md text-center text-sm text-muted-foreground">
+                        Start a test to see your performance history on this dashboard.
                     </p>
-                    <Button asChild className="bg-gradient-blue hover-glow">
+                    <Button asChild size="sm">
                         <Link href="/test">
-                            Take Your First Test
-                            <ArrowRight className="h-4 w-4 ml-1.5" />
+                            Start a test
+                            <ArrowRight className="ml-1.5 h-4 w-4" />
                         </Link>
                     </Button>
                 </>

--- a/components/dashboard/dashboard-filters.tsx
+++ b/components/dashboard/dashboard-filters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Search, SlidersHorizontal, X } from "lucide-react";
+import { Search, X } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -12,8 +12,6 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import type { TestType } from "@/types/global/interface/test-history.interface";
-
-// ─── Types ────────────────────────────────────────────────────────────────
 
 export type TestTypeFilter = TestType | "all";
 export type SortByOption = "attemptedAt" | "score" | "timeTaken";
@@ -30,10 +28,8 @@ interface DashboardFiltersProps {
     onSortOrderChange: (value: SortOrder) => void;
 }
 
-// ─── Filter Tabs ──────────────────────────────────────────────────────────
-
 const testTypeOptions: { value: TestTypeFilter; label: string }[] = [
-    { value: "all", label: "All Tests" },
+    { value: "all", label: "All" },
     { value: "custom", label: "Custom" },
     { value: "cet", label: "CET" },
 ];
@@ -43,8 +39,6 @@ const sortByOptions: { value: SortByOption; label: string }[] = [
     { value: "score", label: "Score" },
     { value: "timeTaken", label: "Duration" },
 ];
-
-// ─── Component ────────────────────────────────────────────────────────────
 
 export function DashboardFilters({
     testType,
@@ -57,24 +51,22 @@ export function DashboardFilters({
     onSortOrderChange,
 }: DashboardFiltersProps) {
     return (
-        <div className="space-y-4">
-            {/* ─── Search + Sort Row ────────────────────────────────── */}
-            <div className="flex flex-col sm:flex-row gap-3">
-                {/* Search */}
-                <div className="relative flex-1 max-w-md">
-                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <div className="space-y-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="relative w-full sm:max-w-sm">
+                    <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                     <Input
                         id="dashboard-search"
                         type="text"
-                        placeholder="Search tests by name or topic…"
+                        placeholder="Search by test or topic"
                         value={search}
                         onChange={(e) => onSearchChange(e.target.value)}
-                        className="pl-9 pr-9 h-9 text-sm"
+                        className="h-9 border bg-background pl-9 pr-9 text-sm"
                     />
                     {search && (
                         <button
                             onClick={() => onSearchChange("")}
-                            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                             aria-label="Clear search"
                         >
                             <X className="h-3.5 w-3.5" />
@@ -82,12 +74,10 @@ export function DashboardFilters({
                     )}
                 </div>
 
-                {/* Sort controls */}
                 <div className="flex items-center gap-2">
-                    <SlidersHorizontal className="h-4 w-4 text-muted-foreground hidden sm:block" />
                     <Select value={sortBy} onValueChange={(v) => onSortByChange(v as SortByOption)}>
-                        <SelectTrigger className="w-[120px] h-9 text-xs" id="sort-by-select">
-                            <SelectValue placeholder="Sort by" />
+                        <SelectTrigger className="h-9 w-[120px] text-xs" id="sort-by-select">
+                            <SelectValue placeholder="Sort" />
                         </SelectTrigger>
                         <SelectContent>
                             {sortByOptions.map((opt) => (
@@ -101,26 +91,22 @@ export function DashboardFilters({
                     <Button
                         variant="outline"
                         size="sm"
-                        className="h-9 px-2.5 text-xs"
+                        className="h-9 px-3 text-xs"
                         onClick={() => onSortOrderChange(sortOrder === "asc" ? "desc" : "asc")}
                         id="sort-order-toggle"
                     >
-                        {sortOrder === "asc" ? "↑ Asc" : "↓ Desc"}
+                        {sortOrder === "asc" ? "Ascending" : "Descending"}
                     </Button>
                 </div>
             </div>
 
-            {/* ─── Test Type Tabs ───────────────────────────────────── */}
-            <Tabs
-                value={testType}
-                onValueChange={(v) => onTestTypeChange(v as TestTypeFilter)}
-            >
-                <TabsList className="h-9 gap-0.5 bg-muted/60 p-0.5 w-full sm:w-auto overflow-x-auto flex-nowrap">
+            <Tabs value={testType} onValueChange={(v) => onTestTypeChange(v as TestTypeFilter)}>
+                <TabsList className="h-9 w-full justify-start gap-1 overflow-x-auto bg-muted/30 p-1 sm:w-auto">
                     {testTypeOptions.map((opt) => (
                         <TabsTrigger
                             key={opt.value}
                             value={opt.value}
-                            className="text-xs px-3 py-1.5 whitespace-nowrap data-[state=active]:bg-background data-[state=active]:shadow-sm transition-all"
+                            className="whitespace-nowrap px-3 text-xs data-[state=active]:shadow-none"
                             id={`filter-tab-${opt.value}`}
                         >
                             {opt.label}

--- a/components/dashboard/dashboard-stats.tsx
+++ b/components/dashboard/dashboard-stats.tsx
@@ -1,16 +1,9 @@
 "use client";
 
 import { motion } from "framer-motion";
-import {
-    ClipboardList,
-    TrendingUp,
-    Clock,
-    Target,
-} from "lucide-react";
+import { ClipboardList, TrendingUp, Clock, Target } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import type { TestHistoryEntry } from "@/types/global/interface/test-history.interface";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────
 
 function formatDuration(seconds: number): string {
     const h = Math.floor(seconds / 3600);
@@ -24,51 +17,32 @@ interface StatsCardProps {
     value: string | number;
     subtitle: string;
     icon: React.ElementType;
-    iconBg: string;
-    iconColor: string;
     index: number;
 }
 
 const statsVariant = {
-    hidden: { opacity: 0, y: 12 },
+    hidden: { opacity: 0, y: 8 },
     visible: (i: number) => ({
         opacity: 1,
         y: 0,
-        transition: { delay: i * 0.08, duration: 0.3 },
+        transition: { delay: i * 0.05, duration: 0.25 },
     }),
 };
 
-function StatsCard({
-    title,
-    value,
-    subtitle,
-    icon: Icon,
-    iconBg,
-    iconColor,
-    index,
-}: StatsCardProps) {
+function StatsCard({ title, value, subtitle, icon: Icon, index }: StatsCardProps) {
     return (
-        <motion.div
-            variants={statsVariant}
-            initial="hidden"
-            animate="visible"
-            custom={index}
-        >
-            <Card className="p-4 border bg-card hover:shadow-md transition-shadow duration-300">
-                <div className="flex items-center gap-3">
-                    <div className={`rounded-lg p-2.5 ${iconBg}`}>
-                        <Icon className={`h-4 w-4 ${iconColor}`} />
+        <motion.div variants={statsVariant} initial="hidden" animate="visible" custom={index}>
+            <Card className="border bg-card p-4">
+                <div className="flex items-start gap-3">
+                    <div className="rounded-md border bg-muted/40 p-2">
+                        <Icon className="h-4 w-4 text-muted-foreground" />
                     </div>
                     <div className="min-w-0">
-                        <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                        <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
                             {title}
                         </p>
-                        <p className="text-xl font-bold text-foreground tabular-nums leading-tight">
-                            {value}
-                        </p>
-                        <p className="text-[11px] text-muted-foreground truncate">
-                            {subtitle}
-                        </p>
+                        <p className="text-lg font-semibold text-foreground">{value}</p>
+                        <p className="text-xs text-muted-foreground">{subtitle}</p>
                     </div>
                 </div>
             </Card>
@@ -76,15 +50,12 @@ function StatsCard({
     );
 }
 
-// ─── Component ────────────────────────────────────────────────────────────
-
 interface DashboardStatsProps {
     tests: TestHistoryEntry[];
     total: number;
 }
 
 export function DashboardStats({ tests, total }: DashboardStatsProps) {
-    // Compute aggregate metrics
     const totalTests = total;
     const avgScore =
         tests.length > 0
@@ -98,39 +69,31 @@ export function DashboardStats({ tests, total }: DashboardStatsProps) {
         {
             title: "Total Tests",
             value: totalTests,
-            subtitle: "Tests attempted",
+            subtitle: "Attempts recorded",
             icon: ClipboardList,
-            iconBg: "bg-[hsl(var(--blue-primary)/0.1)]",
-            iconColor: "text-[hsl(var(--blue-primary))]",
         },
         {
-            title: "Avg Score",
+            title: "Average Score",
             value: `${avgScore}%`,
-            subtitle: "Across all tests",
+            subtitle: "Across visible results",
             icon: TrendingUp,
-            iconBg: "bg-[hsl(var(--status-answered-bg))]",
-            iconColor: "text-[hsl(var(--status-answered-text))]",
         },
         {
             title: "Time Spent",
             value: formatDuration(totalTime),
-            subtitle: "Total practice time",
+            subtitle: "Total duration",
             icon: Clock,
-            iconBg: "bg-[hsl(var(--ginger-primary)/0.1)]",
-            iconColor: "text-[hsl(var(--ginger-primary))]",
         },
         {
             title: "Best Score",
             value: `${bestScore}%`,
-            subtitle: "Personal best",
+            subtitle: "Highest result",
             icon: Target,
-            iconBg: "bg-[hsl(var(--accent-warm)/0.1)]",
-            iconColor: "text-[hsl(var(--accent-warm))]",
         },
     ];
 
     return (
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
             {statsCards.map((card, i) => (
                 <StatsCard key={card.title} {...card} index={i} />
             ))}

--- a/components/dashboard/test-history-card.tsx
+++ b/components/dashboard/test-history-card.tsx
@@ -2,30 +2,16 @@
 
 import Link from "next/link";
 import { motion } from "framer-motion";
-import {
-    HelpCircle,
-    Calendar,
-    ArrowRight,
-    Target,
-    BookOpen,
-    Zap,
-    Timer,
-} from "lucide-react";
+import { HelpCircle, Calendar, ArrowRight, Target, BookOpen, Timer } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-    Tooltip,
-    TooltipContent,
-    TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type {
     TestHistoryEntry,
     TestType,
     TestStatus,
 } from "@/types/global/interface/test-history.interface";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────
 
 function formatDuration(seconds: number): string {
     const h = Math.floor(seconds / 3600);
@@ -54,58 +40,37 @@ function formatTime(isoString: string): string {
     });
 }
 
-const testTypeConfig: Record<
-    TestType,
-    { label: string; icon: React.ElementType; colorClass: string; bgClass: string }
-> = {
+const testTypeConfig: Record<TestType, { label: string; icon: React.ElementType }> = {
     custom: {
-        label: "Custom Test",
+        label: "Custom",
         icon: Target,
-        colorClass: "text-[hsl(var(--ginger-primary))]",
-        bgClass: "bg-[hsl(var(--ginger-primary)/0.1)]",
     },
     cet: {
-        label: "CET Test",
+        label: "CET",
         icon: BookOpen,
-        colorClass: "text-[hsl(var(--accent-cool))]",
-        bgClass: "bg-[hsl(var(--accent-cool)/0.1)]",
     },
 };
 
-const statusConfig: Record<
-    TestStatus,
-    { label: string; colorClass: string; bgClass: string }
-> = {
+const statusConfig: Record<TestStatus, { label: string; tone: string }> = {
     completed: {
         label: "Completed",
-        colorClass: "text-[hsl(var(--status-answered-text))]",
-        bgClass: "bg-[hsl(var(--status-answered-bg))] border-[hsl(var(--status-answered-border))]",
+        tone: "border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950/40 dark:text-green-300",
     },
     submitted: {
         label: "Submitted",
-        colorClass: "text-[hsl(var(--blue-primary))]",
-        bgClass: "bg-[hsl(var(--blue-primary)/0.08)] border-[hsl(var(--blue-primary)/0.2)]",
+        tone: "border-border bg-muted text-foreground",
     },
     auto_submitted: {
-        label: "Auto-Submitted",
-        colorClass: "text-[hsl(var(--status-warning-text))]",
-        bgClass: "bg-[hsl(var(--status-warning-bg))] border-[hsl(var(--status-warning-border))]",
+        label: "Auto-submitted",
+        tone: "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300",
     },
 };
 
-function getScoreColor(score: number): string {
-    if (score >= 80) return "text-[hsl(var(--status-answered-text))]";
-    if (score >= 50) return "text-[hsl(var(--accent-warm))]";
-    return "text-[hsl(var(--status-unanswered-text))]";
+function getScoreTone(score: number): string {
+    if (score >= 80) return "text-green-700 dark:text-green-300";
+    if (score >= 50) return "text-amber-700 dark:text-amber-300";
+    return "text-red-700 dark:text-red-300";
 }
-
-function getScoreBgColor(score: number): string {
-    if (score >= 80) return "bg-[hsl(var(--status-answered-bg))]";
-    if (score >= 50) return "bg-[hsl(var(--status-warning-bg))]";
-    return "bg-[hsl(var(--status-unanswered-bg))]";
-}
-
-// ─── Component ────────────────────────────────────────────────────────────
 
 interface TestHistoryCardProps {
     entry: TestHistoryEntry;
@@ -113,14 +78,13 @@ interface TestHistoryCardProps {
 }
 
 const cardVariants = {
-    hidden: { opacity: 0, y: 16 },
+    hidden: { opacity: 0, y: 10 },
     visible: (i: number) => ({
         opacity: 1,
         y: 0,
         transition: {
-            delay: i * 0.05,
-            duration: 0.35,
-            ease: [0.25, 0.46, 0.45, 0.94],
+            delay: i * 0.04,
+            duration: 0.25,
         },
     }),
 };
@@ -131,143 +95,84 @@ export function TestHistoryCard({ entry, index }: TestHistoryCardProps) {
     const TypeIcon = typeConfig.icon;
 
     const scorePercentage = Math.round(Number(entry.score));
-    const scoreColor = getScoreColor(scorePercentage);
-    const scoreBg = getScoreBgColor(scorePercentage);
+    const scoreTone = getScoreTone(scorePercentage);
 
     return (
-        <motion.div
-            variants={cardVariants}
-            initial="hidden"
-            animate="visible"
-            custom={index}
-        >
-            <Card
-                className="group relative overflow-hidden border bg-card transition-all duration-300
-                   hover:shadow-lg hover:border-primary/20 hover:-translate-y-0.5"
-                id={`test-history-card-${entry.id}`}
-            >
-                {/* Top accent bar */}
-                <div
-                    className={`absolute top-0 left-0 right-0 h-[2px] opacity-60 transition-opacity duration-300 group-hover:opacity-100 ${scorePercentage >= 80
-                        ? "bg-gradient-to-r from-[hsl(var(--status-answered-text))] to-[hsl(var(--status-answered-border))]"
-                        : scorePercentage >= 50
-                            ? "bg-gradient-warm"
-                            : "bg-gradient-to-r from-[hsl(var(--status-unanswered-text))] to-[hsl(var(--status-unanswered-border))]"
-                        }`}
-                />
+        <motion.div variants={cardVariants} initial="hidden" animate="visible" custom={index}>
+            <Card className="border bg-card p-4" id={`test-history-card-${entry.id}`}>
+                <div className="mb-3 flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                        <h3 className="truncate text-sm font-semibold text-foreground">{entry.testName}</h3>
+                        <div className="mt-1 inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                            <TypeIcon className="h-3.5 w-3.5" />
+                            {typeConfig.label}
+                        </div>
+                    </div>
 
-                <div className="p-5">
-                    {/* ─── Header Row: Test Type + Status ─────────────────── */}
-                    <div className="flex items-start justify-between gap-3 mb-3.5">
-                        <div className="flex items-center gap-2.5 min-w-0">
-                            <div
-                                className={`flex-shrink-0 rounded-lg p-2 ${typeConfig.bgClass}`}
+                    <Badge className={`border px-2 py-0.5 text-[10px] font-medium ${stConfig.tone}`}>
+                        {stConfig.label}
+                    </Badge>
+                </div>
+
+                <div className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-muted-foreground">
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span className="inline-flex items-center gap-1.5">
+                                <Calendar className="h-3.5 w-3.5" />
+                                {formatDate(entry.attemptedAt)}
+                            </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            {formatDate(entry.attemptedAt)} at {formatTime(entry.attemptedAt)}
+                        </TooltipContent>
+                    </Tooltip>
+
+                    <span className="inline-flex items-center gap-1.5">
+                        <HelpCircle className="h-3.5 w-3.5" />
+                        {entry.totalQuestions} Qs
+                    </span>
+
+                    <span className="inline-flex items-center gap-1.5">
+                        <Timer className="h-3.5 w-3.5" />
+                        {formatDuration(entry.timeTaken)}
+                    </span>
+                </div>
+
+                {entry.testType === "custom" && entry.topics.length > 0 && (
+                    <div className="mb-3 flex flex-wrap gap-1.5">
+                        {entry.topics.slice(0, 4).map((topic) => (
+                            <span
+                                key={topic}
+                                className="inline-flex items-center rounded-md border bg-muted/30 px-2 py-0.5 text-[11px] text-muted-foreground"
                             >
-                                <TypeIcon className={`h-4 w-4 ${typeConfig.colorClass}`} />
-                            </div>
-                            <div className="min-w-0">
-                                <h3 className="text-sm font-semibold text-foreground truncate leading-tight">
-                                    {entry.testName}
-                                </h3>
-                                <span
-                                    className={`text-xs font-medium ${typeConfig.colorClass}`}
-                                >
-                                    {typeConfig.label}
-                                </span>
-                            </div>
-                        </div>
+                                {topic}
+                            </span>
+                        ))}
+                        {entry.topics.length > 4 && (
+                            <span className="inline-flex items-center rounded-md border bg-muted/30 px-2 py-0.5 text-[11px] text-muted-foreground">
+                                +{entry.topics.length - 4}
+                            </span>
+                        )}
+                    </div>
+                )}
 
-                        <Badge
-                            className={`text-[10px] font-semibold px-2 py-0.5 border ${stConfig.bgClass} ${stConfig.colorClass} shrink-0`}
-                        >
-                            {stConfig.label}
-                        </Badge>
+                <div className="flex items-center justify-between border-t pt-3">
+                    <div>
+                        <p className="text-xs text-muted-foreground">Score</p>
+                        <p className={`text-sm font-semibold ${scoreTone}`}>
+                            {scorePercentage}%
+                            <span className="ml-1 text-muted-foreground">
+                                ({entry.correctAnswers}/{entry.totalQuestions})
+                            </span>
+                        </p>
                     </div>
 
-                    {/* ─── Meta Row: Date, Questions, Time ────────────────── */}
-                    <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-muted-foreground mb-3.5">
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <span className="inline-flex items-center gap-1.5">
-                                    <Calendar className="h-3.5 w-3.5" />
-                                    {formatDate(entry.attemptedAt)}
-                                </span>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                {formatDate(entry.attemptedAt)} at {formatTime(entry.attemptedAt)}
-                            </TooltipContent>
-                        </Tooltip>
-
-                        <span className="inline-flex items-center gap-1.5">
-                            <HelpCircle className="h-3.5 w-3.5" />
-                            {entry.totalQuestions} Qs
-                        </span>
-
-                        <span className="inline-flex items-center gap-1.5">
-                            <Timer className="h-3.5 w-3.5" />
-                            {formatDuration(entry.timeTaken)}
-                        </span>
-                    </div>
-
-                    {/* ─── Topics (only for custom tests) ──────────────────── */}
-                    {entry.testType === "custom" && entry.topics.length > 0 && (
-                        <div className="flex flex-wrap gap-1.5 mb-3.5">
-                            {entry.topics.slice(0, 4).map((topic) => (
-                                <span
-                                    key={topic}
-                                    className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
-                                >
-                                    <Zap className="h-2.5 w-2.5" />
-                                    {topic}
-                                </span>
-                            ))}
-                            {entry.topics.length > 4 && (
-                                <Tooltip>
-                                    <TooltipTrigger asChild>
-                                        <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground cursor-default">
-                                            +{entry.topics.length - 4} more
-                                        </span>
-                                    </TooltipTrigger>
-                                    <TooltipContent className="max-w-[240px]">
-                                        <p className="text-xs">{entry.topics.slice(4).join(", ")}</p>
-                                    </TooltipContent>
-                                </Tooltip>
-                            )}
-                        </div>
-                    )}
-
-                    {/* ─── Score + CTA Row ──────────────────────────────────── */}
-                    <div className="flex items-center justify-between pt-3 border-t border-border/60">
-                        <div className="flex items-center gap-3">
-                            {/* Score circle */}
-                            <div
-                                className={`flex items-center justify-center w-11 h-11 rounded-full ${scoreBg}`}
-                            >
-                                <span className={`text-sm font-bold ${scoreColor}`}>
-                                    {scorePercentage}%
-                                </span>
-                            </div>
-                            <div>
-                                <p className="text-xs text-muted-foreground">Score</p>
-                                <p className="text-sm font-semibold text-foreground">
-                                    {entry.correctAnswers}/{entry.totalQuestions}
-                                </p>
-                            </div>
-                        </div>
-
-                        <Button
-                            asChild
-                            variant="outline"
-                            size="sm"
-                            className="group/btn transition-all duration-200 hover:bg-primary hover:text-primary-foreground hover:border-primary"
-                            id={`view-result-${entry.id}`}
-                        >
-                            <Link href={`/result/${entry.resultId}`}>
-                                View Result
-                                <ArrowRight className="h-3.5 w-3.5 ml-1 transition-transform group-hover/btn:translate-x-0.5" />
-                            </Link>
-                        </Button>
-                    </div>
+                    <Button asChild variant="ghost" size="sm" className="h-8 px-2 text-xs" id={`view-result-${entry.id}`}>
+                        <Link href={`/result/${entry.resultId}`}>
+                            View result
+                            <ArrowRight className="ml-1 h-3.5 w-3.5" />
+                        </Link>
+                    </Button>
                 </div>
             </Card>
         </motion.div>


### PR DESCRIPTION
### Motivation
- The dashboard had gradient-heavy, high-contrast visuals and inconsistent spacing that contrasted with the app's neutral surface patterns, so it needed a minimalist, lower-contrast treatment to match the rest of the UI.
- The goal was to reduce visual noise while keeping the same data and interactions (filters, stats, cards, pagination).

### Description
- Simplified the page header in `app/dashboard/page.tsx` to use a neutral bordered icon container and lighter typography to match the app surface styles.
- Reworked stats into subdued cards in `components/dashboard/dashboard-stats.tsx` with muted icon treatment, smaller motion timings, and simplified copy while preserving the same metrics.
- Streamlined search, sort and tab controls in `components/dashboard/dashboard-filters.tsx` to use lower-weight labels and neutral input/select styling for a cleaner look.
- Refactored test cards in `components/dashboard/test-history-card.tsx` to a flatter card layout with restrained status and score tones, simplified topic chips, and reduced animation durations.
- Converted the empty state into a compact, bordered card style in `components/dashboard/dashboard-empty-state.tsx` with simplified messaging and CTAs.

### Testing
- Ran `npm run lint` and confirmed lint completed (only unrelated warnings remain in other files). 
- Started the dev server and captured a visual checkpoint with Playwright at `/dashboard` to validate the minimalist layout; the environment experienced intermittent Google Fonts fetch failures and fell back to local fonts during the screenshot but page rendered successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a915b8707483248be57a1479803860)